### PR TITLE
Fix react-hooks findings surfaced by eslint-plugin-react-hooks v7

### DIFF
--- a/src/components/Vehicle/DetailsButton.tsx
+++ b/src/components/Vehicle/DetailsButton.tsx
@@ -9,10 +9,10 @@ type DetailsButtonProps = {
 };
 
 export function DetailsButton({ vehicleData }: DetailsButtonProps) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
   if (!vehicleData) {
     return null;
   }
-  const [detailsOpen, setDetailsOpen] = useState(false);
   return (
     <>
       <Tooltip title={"Show details"}>

--- a/src/hooks/useSubscriptionClient.ts
+++ b/src/hooks/useSubscriptionClient.ts
@@ -1,12 +1,12 @@
 import { createClient } from "graphql-ws";
 import { useConfig } from "../config/ConfigContext.ts";
-import { useRef } from "react";
+import { useState } from "react";
 import { useRequestHeaders } from "./useRequestHeaders.ts";
 
 export const useSubscriptionClient = () => {
   const config = useConfig();
   const requestHeaders = useRequestHeaders();
-  const client = useRef(
+  const [client] = useState(() =>
     createClient({
       url: config["vehicle-positions-subscriptions-endpoint"],
       connectionParams: {
@@ -14,5 +14,5 @@ export const useSubscriptionClient = () => {
       },
     }),
   );
-  return client.current;
+  return client;
 };

--- a/src/hooks/useVehiclePositionsData.ts
+++ b/src/hooks/useVehiclePositionsData.ts
@@ -77,9 +77,7 @@ export const useVehiclePositionsData = (
   mapViewOptions: MapViewOptions,
 ) => {
   const map = useRef<CacheMap<string, VehicleData>>(new CacheMap());
-  const [data, setData] = useState<VehicleData[]>(
-    Array.from(map.current.values()),
-  );
+  const [data, setData] = useState<VehicleData[]>([]);
   const subscription =
     useRef<AsyncIterableIterator<FormattedExecutionResult<Data, unknown>>>(
       null,


### PR DESCRIPTION
Follow-up to #133, which upgraded `eslint-plugin-react-hooks` to v7. Its stricter rules surfaced one real bug plus some non-idiomatic patterns. This PR fixes the clear, behaviour-preserving ones.

## Fixes
- **`DetailsButton` — real `rules-of-hooks` bug.** `useState` was called *after* the `if (!vehicleData) return null` early return, so the hook order changed whenever `vehicleData` flipped null↔non-null. Moved the hook above the guard.
- **`useSubscriptionClient`** — `useRef(createClient(...))` invoked `createClient` on *every* render (only the first result was ever kept). Switched to `useState(() => createClient(...))`: created once, lazily — identical behaviour, no per-render waste, no ref read during render.
- **`useVehiclePositionsData`** — `data` state was initialised from a freshly-created empty `CacheMap`; replaced with `[]` (equivalent, drops the render-time ref read).

## Deliberately not changed
The 5 remaining `react-hooks/set-state-in-effect` findings are all "reset/sync state when a dependency changes" patterns (e.g. `setRoute(null)` when the id clears, `setTimetable(null)` before re-subscribing). They work correctly; converting them to key-based resets / derived state is behaviour-sensitive and out of scope here. Lint is not part of CI, so they don't block.

## Verification
- `npm run build` ✓ · `npm run check` (prettier) ✓ · Playwright smoke tests ✓ 3/3
- Lint: 23 → 19 problems (the `rules-of-hooks` + both `refs` errors cleared)